### PR TITLE
Added deeplinking to FAQ page

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -231,12 +231,14 @@
             </div>
         <div class="row justify-content-center">
             <div class="col-8">
-                <div class="py-1">
+                <div class="py-1" id="WhatIsGPC">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#WhatIsGPC">
                               What is the Global Privacy Control (GPC)? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -261,12 +263,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="WhoIsGPC">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#WhoIsGPC">
                               Who is supporting the development of GPC? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -296,12 +300,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="HowToSignal">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#HowToSignal">
                               I’m a web user. How can I use GPC to signal my privacy preferences to websites? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -319,12 +325,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="Publisher">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#Publisher">
                               I’m a publisher, developer, or other service. How can I support GPC? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -344,12 +352,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="Policymaker">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#Policymaker">
                               I’m a policymaker. How can I support GPC or learn more about how it could apply in my jurisdiction? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -368,12 +378,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="GetInvolved">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#GetInvolved">
                               How can I get involved in developing the proposed specification? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -397,12 +409,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="Benefit">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#Benefit">
                               How does GPC benefit consumers, publishers, software makers, and advertisers? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -429,12 +443,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="IsItBinding">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#IsItBinding">
                               Is GPC legally binding?
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -490,12 +506,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="DNT">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#DNT">
                               Why not just use Do Not Track (DNT)? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -533,12 +551,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="ExistingDNS">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#ExistingDNS">
                               How does GPC interact with companies' existing Do Not Sell links? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -556,12 +576,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="Conflict">
                     <button type="button" class="collapsible">
                         <div class="container">
                         <div class="row justify-content-between align-items-center">
                             <div class="col-11 p-0">
+                              <a class="stretched-link" href="#Conflict">
                               What if there is a conflict between a GPC signal and a user-selected privacy preference? 
+                              </a>
                         </div>
                         <div class="col-1 p-0 text-right">
                             <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">
@@ -590,12 +612,14 @@
                                 </div>
                         </div>
                 </div>
-                <div class="py-1">
+                <div class="py-1" id="Default">
                   <button type="button" class="collapsible">
                       <div class="container">
                       <div class="row justify-content-between align-items-center">
                           <div class="col-11 p-0">
+                            <a class="stretched-link" href="#Default">
                             Can GPC be enabled by default? 
+                            </a>
                       </div>
                       <div class="col-1 p-0 text-right">
                           <img class="arrow-icons" id="down" src="../static/img/arrow-icons/caret-right-fill.svg">

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "parcel /index.html press/index.html faq/index.html",
+    "dev": "parcel /index.html press/index.html faq/*.html",
     "build": "parcel build index.html press-release/*.html"
   },
   "staticFiles": {

--- a/static/css/faq.scss
+++ b/static/css/faq.scss
@@ -50,6 +50,11 @@ header {
     &:focus{
       outline: none;
     }
+
+    a {
+      color: inherit;
+      text-decoration: inherit;
+    }
   }
   
   /* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */


### PR DESCRIPTION
You can now right-click on the question to copy a link that will lead right to that question, like with a regular link.