### PR TITLE
Update home.js

### DIFF
--- a/src/components/home.js
+++ b/src/components/home.js
@@ -313,7 +313,7 @@ export default function Home({ pressData, faqData, orgsData, downloadsData }) {
                     </div>
                     <div className={styles.tableDesc}>{name}</div>
                     <div className={styles.tableLink}>
-                      <a className="stretched-link" href={url}>
+                      <a className={` ${styles.tableLink} stretched-link`} href={url}>
                         LEARN MORE <VisuallyHidden>about {name}</VisuallyHidden>
                       </a>
                     </div>


### PR DESCRIPTION
Made sure that the "learn more" links on the download table disappear correctly on small breakpoint. Previously they were causing the page to be wider than it should be, adding a white bar on the right side on mobile.