### PR TITLE
Add 50ms timeout to GPC DOM check

### DIFF
--- a/src/components/status-bar.js
+++ b/src/components/status-bar.js
@@ -6,7 +6,12 @@ export default function StatusBar() {
   const [hasGpc, setHasGpc] = useState(undefined);
 
   useEffect(() => {
-    setHasGpc(!!navigator.globalPrivacyControl);
+    const timeoutId = setTimeout(() => {
+      setHasGpc(!!navigator.globalPrivacyControl);
+    }, 50);
+    return () => {
+      clearTimeout(timeoutId);
+    };
   }, []);
 
   if (hasGpc === undefined) {


### PR DESCRIPTION
We seem to be running into a race condition when injecting the DOM signal using a Chrome MV3 extension - there is a slight delay between initial page load and script injection that is causing the status indicator to occasionally show the GPC DOM signal is  not present when it actually is.

We will continue to try to work around this issue, but in the meantime to avoid confusion (telling users their GPC signal isn't present when it is) we will try adding a 50ms timeout to the status indicator.

See also: https://github.com/privacy-tech-lab/gpc-optmeowt/issues/339

cc @SebastianZimmeck @oliverwang13