### PR TITLE
Fix double-dot typo

### DIFF
--- a/src/components/status-bar.js
+++ b/src/components/status-bar.js
@@ -40,7 +40,7 @@ export default function StatusBar() {
                   <span className={`${styles.statusCheck}`}>
                     Test against the
                     <a href="https://global-privacy-control.glitch.me">
-                      reference server.
+                      reference server
                     </a>
                     .
                   </span>
@@ -53,9 +53,7 @@ export default function StatusBar() {
                   <span className={`${styles.statusText}`}>
                     Please
                     <Link href="/#download">
-                      <a>
-                        download a browser/extension
-                      </a>
+                      <a>download a browser/extension</a>
                     </Link>
                     that supports it.
                   </span>


### PR DESCRIPTION
A very minor issue. I removed one of the dots from the following.

<img width="403" alt="Screen Shot 2022-09-15 at 1 51 36 PM" src="https://user-images.githubusercontent.com/11034003/190475329-e20f8344-0032-443c-93c1-49380a15e4e1.png">
