### PR TITLE
Update gpc.json to match current specifications

### DIFF
--- a/public/.well-known/gpc.json
+++ b/public/.well-known/gpc.json
@@ -1,4 +1,4 @@
 {
   "gpc": true,
-  "version": 1
+  "lastUpdate": "2021-05-13"
 }


### PR DESCRIPTION
Since this [commit](https://github.com/globalprivacycontrol/gpc-spec/commit/6ff08fe4c128f7eb3bcf20daca489b1a833cc747) the `version` member was replaced by the `lastUpdate` member. 

I choose the date of the commit as the `lastUpdate` value.