### PR TITLE
Squash console error on homepage

### DIFF
--- a/content/orgs.md
+++ b/content/orgs.md
@@ -104,6 +104,7 @@ entries:
     browser_img: /img/browser-logos/privacybadger.svg
     type: Downloadable
   - name: privacy-tech-lab
+    img: /img/participating-logos/optmeowt.svg
     url: https://privacytechlab.org/
     type: Business
   - name: Raptive


### PR DESCRIPTION
The changes in #51 caused a console error on the homepage due to a missing img attribute. We aren't actually showing an image for this org anywhere, but adding one anyway to squash the error.