### PR TITLE
Bump node version to 18

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v2.1.2
         with:
-          node-version: '14'
+          node-version: '18.12.1'
 
       - name: Cache node modules
         uses: actions/cache@v2


### PR DESCRIPTION
Updating `next` in https://github.com/globalprivacycontrol/landing-page/pull/65 caused an issue with our build and deploy action. Updating node to 18.12.1 _should_ resolve this issue.