### PR TITLE
Bump react to 18.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "postcss-flexbugs-fixes": "^5.0.2",
         "postcss-preset-env": "^7.4.1",
         "postcss-url": "^10.1.3",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "remark": "^14.0.2",
         "remark-html": "^15.0.1",
         "sass": "^1.49.9"
@@ -37,13 +37,13 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
-      "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -74,27 +74,27 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
-      "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.0",
-        "@babel/helper-compilation-targets": "^7.19.1",
-        "@babel/helper-module-transforms": "^7.19.0",
-        "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.1",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.1",
-        "@babel/types": "^7.19.0",
-        "convert-source-map": "^1.7.0",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.3",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.2",
+        "@babel/parser": "^7.23.3",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
-        "semver": "^6.3.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -123,12 +123,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -137,38 +137,39 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
-      "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@babel/compat-data": "^7.19.1",
-        "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.21.3",
-        "semver": "^6.3.0"
+        "@babel/compat-data": "^7.22.9",
+        "@babel/helper-validator-option": "^7.22.15",
+        "browserslist": "^4.21.9",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.22.20",
@@ -205,46 +206,46 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
-      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -281,9 +282,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -291,15 +292,15 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
-      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -320,9 +321,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -371,19 +372,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -392,9 +393,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -590,14 +591,14 @@
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -1293,9 +1294,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1304,13 +1305,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1353,9 +1358,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001409",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ==",
+      "version": "1.0.30001561",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
+      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1364,6 +1369,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -1494,14 +1503,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
+      "peer": true
     },
     "node_modules/core-js-pure": {
       "version": "3.21.1",
@@ -1691,9 +1697,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.257",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz",
-      "integrity": "sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A=="
+      "version": "1.4.581",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.581.tgz",
+      "integrity": "sha512-6uhqWBIapTJUxgPTCHH9sqdbxIMPt7oXl0VcAL1kOtlU6aECdcMncCrX5Z7sHQ/invtrC9jUQUef7+HhO8vVFw=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3069,9 +3075,9 @@
       "dev": true
     },
     "node_modules/jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "peer": true
     },
     "node_modules/js-tokens": {
@@ -3938,9 +3944,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3962,6 +3968,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4762,28 +4769,26 @@
       ]
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
@@ -4981,13 +4986,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/sass": {
       "version": "1.49.9",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
@@ -5005,12 +5003,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/section-matter": {
@@ -5357,9 +5354,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -5367,7 +5364,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -5482,9 +5479,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
-      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5493,6 +5490,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -5500,7 +5501,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -5655,13 +5656,13 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
@@ -5676,34 +5677,34 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
-      "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
+      "integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
       "dev": true,
       "peer": true
     },
     "@babel/core": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
-      "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
+      "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.19.0",
-        "@babel/helper-compilation-targets": "^7.19.1",
-        "@babel/helper-module-transforms": "^7.19.0",
-        "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.1",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.1",
-        "@babel/types": "^7.19.0",
-        "convert-source-map": "^1.7.0",
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.3",
+        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.2",
+        "@babel/parser": "^7.23.3",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.3",
+        "@babel/types": "^7.23.3",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
-        "semver": "^6.3.0"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       }
     },
     "@babel/eslint-parser": {
@@ -5718,41 +5719,48 @@
       }
     },
     "@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
+      "integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.23.0",
+        "@babel/types": "^7.23.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
-      },
-      "dependencies": {
-        "@jridgewell/gen-mapping": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/set-array": "^1.0.1",
-            "@jridgewell/sourcemap-codec": "^1.4.10",
-            "@jridgewell/trace-mapping": "^0.3.9"
-          }
-        }
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
-      "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
+      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@babel/compat-data": "^7.19.1",
-        "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.21.3",
-        "semver": "^6.3.0"
+        "@babel/compat-data": "^7.22.9",
+        "@babel/helper-validator-option": "^7.22.15",
+        "browserslist": "^4.21.9",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "@babel/helper-environment-visitor": {
@@ -5781,40 +5789,37 @@
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.15"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
-      "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.18.6",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-      "integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.5"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -5839,22 +5844,22 @@
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
+      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
       "dev": true,
       "peer": true
     },
     "@babel/helpers": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.0.tgz",
-      "integrity": "sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+      "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
-        "@babel/types": "^7.19.0"
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.2",
+        "@babel/types": "^7.23.0"
       }
     },
     "@babel/highlight": {
@@ -5869,9 +5874,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
+      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
       "dev": true
     },
     "@babel/runtime": {
@@ -5905,27 +5910,27 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
+      "integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/generator": "^7.23.3",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/parser": "^7.23.3",
+        "@babel/types": "^7.23.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
+      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -6057,14 +6062,14 @@
       "dev": true
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "dev": true,
-      "peer": true,
       "requires": {
-        "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@jridgewell/resolve-uri": {
@@ -6524,14 +6529,14 @@
       }
     },
     "browserslist": {
-      "version": "4.21.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001400",
-        "electron-to-chromium": "^1.4.251",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.9"
+        "caniuse-lite": "^1.0.30001541",
+        "electron-to-chromium": "^1.4.535",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "busboy": {
@@ -6559,9 +6564,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001409",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001409.tgz",
-      "integrity": "sha512-V0mnJ5dwarmhYv8/MzhJ//aW68UpvnQBXv8lJ2QUsvn2pHcmAuNtu8hQEDz37XnA1iE+lRR9CIfGWWpgJ5QedQ=="
+      "version": "1.0.30001561",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz",
+      "integrity": "sha512-NTt0DNoKe958Q0BE0j0c1V9jbUzhBxHIEJy7asmGrpE0yG63KTV7PLHPnK2E1O9RsQrQ081I3NLuXGS6zht3cw=="
     },
     "ccount": {
       "version": "2.0.1",
@@ -6655,14 +6660,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "peer": true,
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
+      "peer": true
     },
     "core-js-pure": {
       "version": "3.21.1",
@@ -6784,9 +6786,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.257",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz",
-      "integrity": "sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A=="
+      "version": "1.4.581",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.581.tgz",
+      "integrity": "sha512-6uhqWBIapTJUxgPTCHH9sqdbxIMPt7oXl0VcAL1kOtlU6aECdcMncCrX5Z7sHQ/invtrC9jUQUef7+HhO8vVFw=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -7786,9 +7788,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "peer": true
     },
     "js-tokens": {
@@ -8312,9 +8314,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -8329,7 +8331,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.12.0",
@@ -8846,22 +8849,20 @@
       "dev": true
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       }
     },
     "react-is": {
@@ -8992,13 +8993,6 @@
         "mri": "^1.1.0"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "peer": true
-    },
     "sass": {
       "version": "1.49.9",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
@@ -9010,12 +9004,11 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "section-matter": {
@@ -9257,9 +9250,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "peer": true
     },
@@ -9340,9 +9333,9 @@
       }
     },
     "update-browserslist-db": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.9.tgz",
-      "integrity": "sha512-/xsqn21EGVdXI3EXSum1Yckj3ZVZugqyOZQ/CxYPBD/R+ko9NSUScf8tFF4dOKY+2pvSSJA/S+5B8s4Zr4kyvg==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-preset-env": "^7.4.1",
     "postcss-url": "^10.1.3",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "remark": "^14.0.2",
     "remark-html": "^15.0.1",
     "sass": "^1.49.9"

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -16,456 +16,454 @@ export default function Home({
   downloadsData,
   testimonialsData
 }) {
-  return (
-    <>
-      {/* <!-- HERO SECTION --> */}
-      <section className={styles.heroBackground}>
-        <header className="container">
-          <Navbar isLarge={true} />
-        </header>
+  return <>
+    {/* <!-- HERO SECTION --> */}
+    <section className={styles.heroBackground}>
+      <header className="container">
+        <Navbar isLarge={true} />
+      </header>
 
-        <div className={styles.hero}>
-          <div className="container">
-            <div className="row">
-              <div className="col-12 col-lg-7">
-                <h1 className={styles.heroTitle}>
-                  Take control of your privacy.
-                </h1>
-                <p className={styles.heroText}>
-                  Online privacy should be accessible to everyone. It starts
-                  with a simpler way to exercise your rights.
-                </p>
-
-                {/* <!-- HERO BUTTONSs --> */}
-                <div className={`row ${styles.heroBtns}`}>
-                  <div className="col-sm-12 col-md-6 mb-5 mb-lg-0">
-                    <Link href="/#download" passHref>
-                      <Button
-                        as="a"
-                        variant="primaryInverted"
-                        className="d-block"
-                      >
-                        Get Started
-                      </Button>
-                    </Link>
-                  </div>
-                  <div className="col-sm-12 col-md-6">
-                    <Link href="/#contact" passHref>
-                      <Button
-                        as="a"
-                        variant="secondaryInverted"
-                        className="d-block"
-                      >
-                        Get Involved
-                      </Button>
-                    </Link>
-                  </div>
-                </div>
-              </div>
-
-              <div className="d-none d-lg-block col-lg-5">
-                <img
-                  src={`${process.env.publicPrefix}/img/person-with-computer.svg`}
-                  id="hero-illustration"
-                  className="ml-5 img-fluid"
-                  alt="man sitting at a computer"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* <!-- NEWS SECTION --> */}
-      <section className={`${styles.news} py-5 px-3 px-sm-4`}>
-        <div className={styles.newsAnnouncement}>
-          <div className="container">
-            <div className="row justify-content-center align-items-center">
-              {/*<!-- HORN ICON --> */}
-              <span className="p-3">
-                <svg
-                  width="39"
-                  height="28"
-                  viewBox="0 0 39 28"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                    d="M22.556 0.18225C22.8823 -0.0216922 23.2902 -0.0624807 23.6165 0.100673C23.9428 0.304616 24.1468 0.630924 24.1876 0.99802V25.2264C24.1876 25.5935 23.9428 25.9606 23.6165 26.1237C23.4942 26.2053 23.331 26.2461 23.1679 26.2461C22.9639 26.2461 22.7192 26.1645 22.556 26.0422L12.7668 18.6594H10.034L11.4616 26.8171C11.5431 27.1027 11.4616 27.3882 11.2576 27.6329C11.0537 27.8776 10.7682 28 10.4826 28H6.56695C6.07748 28 5.6696 27.6329 5.58802 27.1434L4.11964 18.6594H2.93677C1.30523 18.6594 0 17.3542 0 15.7227V10.5017C0 8.8702 1.30523 7.56497 2.93677 7.56497H12.7668L22.556 0.18225ZM33.9359 2.34379C33.2833 1.73197 32.2636 1.81354 31.6517 2.46616C31.0399 3.11878 31.1215 4.13849 31.7741 4.75031C34.1806 6.87132 35.5266 9.93045 35.5266 13.1527C35.5266 16.3342 34.1398 19.3934 31.7741 21.5552C31.1215 22.167 31.0399 23.1867 31.6517 23.8393C31.978 24.2064 32.4267 24.3696 32.8346 24.3696C33.2017 24.3696 33.6096 24.2472 33.8951 23.9617C36.9542 21.2289 38.7081 17.2724 38.7081 13.1527C38.7489 9.0739 36.995 5.11741 33.9359 2.34379ZM30.2231 6.95259C29.5705 6.34077 28.5507 6.34077 27.9389 6.99338C27.3271 7.646 27.3271 8.66571 27.9797 9.27754C29.0402 10.2972 29.6112 11.6433 29.6112 13.1117C29.6112 14.58 29.0402 15.9261 27.9797 16.9458C27.3271 17.5576 27.3271 18.5773 27.9389 19.2299C28.2652 19.5562 28.6731 19.7194 29.1218 19.7194C29.5297 19.7194 29.9376 19.5562 30.2231 19.2707C31.9362 17.6392 32.8335 15.4366 32.8335 13.1117C32.8335 10.7867 31.8954 8.58413 30.2231 6.95259Z"
-                    fill="white"
-                  />
-                </svg>
-              </span>
-
-              <p className="mb-0 py-3 text-center">
-                <Link href="/press-release/20210128">
-                  <a>Read the Latest Press Release</a>
-                </Link>{' '}
-                and{' '}
-                <a
-                  href="https://twitter.com/globalprivctrl"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Follow @globalprivctrl on Twitter
-                </a>
-                .
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/*<!-- ABOUT SECTION --> */}
-      <section id="about" className={styles.about}>
-        <div className="container">
-          <div className={`${styles.aboutCards} row row-cols-1 row-cols-lg-3`}>
-            <div className="col">
-              <div
-                className={`card ${styles.aboutCard} h-100 text-center border-0`}
-              >
-                <img
-                  src={`${process.env.publicPrefix}/img/turn-on-gpc.svg`}
-                  className="card-img-top"
-                  alt="Turn On GPC placeholder"
-                />
-                <div className="card-body">
-                  <h2 className="card-title">
-                    Turn On <abbr title="Global Privacy Control">GPC</abbr>
-                  </h2>
-                  <p className="card-text">
-                    Enable Global Privacy Control to communicate your privacy
-                    preference.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className="col">
-              <div
-                className={`card ${styles.aboutCard} h-100 text-center border-0`}
-              >
-                <img
-                  src={`${process.env.publicPrefix}/img/browser-fights-for-you.svg`}
-                  className="card-img-top"
-                  alt="Turn On GPC placeholder"
-                />
-                <div className="card-body">
-                  <h2 className="card-title">Send the Signal</h2>
-                  <p className="card-text">
-                    Your browser will send the{' '}
-                    <abbr title="Global Privacy Control">GPC</abbr> signal to
-                    websites you visit.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className="col">
-              <div
-                className={`card ${styles.aboutCard} h-100 text-center border-0`}
-              >
-                <img
-                  src={`${process.env.publicPrefix}/img/live-more-privately.svg`}
-                  className="card-img-top"
-                  alt="Turn On GPC placeholder"
-                />
-                <div className="card-body">
-                  <h2 className="card-title">Exercise Your Rights</h2>
-                  <p className="card-text">
-                    Participating websites can respect your privacy rights
-                    accordingly.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* <!-- HORIZONTAL DIVIDER --> */}
-        <div className={styles.aboutSec2}>
-          <img
-            src={`${process.env.publicPrefix}/img/divider-lines.svg`}
-            alt="dividing placeholder"
-          />
-        </div>
-
-        <div className="about-sec-3">
-          <div className="container text-lg-center">
-            <div className="row justify-content-center">
-              <div className="col-lg-8">
-                <div className={`${styles.aboutText} ${styles.sectionText}`}>
-                  <p>
-                    You may have noticed “Do Not Sell” and “Object To
-                    Processing” links around the web from companies complying
-                    with privacy regulations. To opt out of websites selling or
-                    sharing your personal information, you need to click these
-                    links for every site you visit.
-                  </p>
-                  <p>
-                    Now you can exercise your legal privacy rights in one step
-                    via Global Privacy Control (
-                    <abbr title="Global Privacy Control">GPC</abbr>), required
-                    under the California Consumer Protection Act (CCPA).
-                  </p>
-
-                  <p className="font-weight-bolder">
-                    Together, over a dozen organizations are developing the{' '}
-                    <abbr title="Global Privacy Control">GPC</abbr>{' '}
-                    specification.{' '}
-                    <a href="#contact">
-                      <u>Get Involved</u>
-                    </a>
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/*<!-- GPC SPEC SECTION --> */}
-      <section
-        id="gpc-spec"
-        className={`${styles.section} ${styles.sectionDark}`}
-      >
+      <div className={styles.hero}>
         <div className="container">
           <div className="row">
-            <div className="col-12 col-lg-5">
-              <h2 className={styles.sectionTitle}>
-                <abbr title="Global Privacy Control">GPC</abbr> lets users
-                signal their desired privacy, just by browsing.
-              </h2>
+            <div className="col-12 col-lg-7">
+              <h1 className={styles.heroTitle}>
+                Take control of your privacy.
+              </h1>
+              <p className={styles.heroText}>
+                Online privacy should be accessible to everyone. It starts
+                with a simpler way to exercise your rights.
+              </p>
 
-              <div className={styles.sectionText}>
-                <p>
-                  <abbr title="Global Privacy Control">GPC</abbr> is available as part of
-                  several major browsers, extensions, and websites.
+              {/* <!-- HERO BUTTONSs --> */}
+              <div className={`row ${styles.heroBtns}`}>
+                <div className="col-sm-12 col-md-6 mb-5 mb-lg-0">
+                  <Link href="/#download" passHref legacyBehavior>
+                    <Button
+                      as="a"
+                      variant="primaryInverted"
+                      className="d-block"
+                    >
+                      Get Started
+                    </Button>
+                  </Link>
+                </div>
+                <div className="col-sm-12 col-md-6">
+                  <Link href="/#contact" passHref legacyBehavior>
+                    <Button
+                      as="a"
+                      variant="secondaryInverted"
+                      className="d-block"
+                    >
+                      Get Involved
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+            </div>
+
+            <div className="d-none d-lg-block col-lg-5">
+              <img
+                src={`${process.env.publicPrefix}/img/person-with-computer.svg`}
+                id="hero-illustration"
+                className="ml-5 img-fluid"
+                alt="man sitting at a computer"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {/* <!-- NEWS SECTION --> */}
+    <section className={`${styles.news} py-5 px-3 px-sm-4`}>
+      <div className={styles.newsAnnouncement}>
+        <div className="container">
+          <div className="row justify-content-center align-items-center">
+            {/*<!-- HORN ICON --> */}
+            <span className="p-3">
+              <svg
+                width="39"
+                height="28"
+                viewBox="0 0 39 28"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M22.556 0.18225C22.8823 -0.0216922 23.2902 -0.0624807 23.6165 0.100673C23.9428 0.304616 24.1468 0.630924 24.1876 0.99802V25.2264C24.1876 25.5935 23.9428 25.9606 23.6165 26.1237C23.4942 26.2053 23.331 26.2461 23.1679 26.2461C22.9639 26.2461 22.7192 26.1645 22.556 26.0422L12.7668 18.6594H10.034L11.4616 26.8171C11.5431 27.1027 11.4616 27.3882 11.2576 27.6329C11.0537 27.8776 10.7682 28 10.4826 28H6.56695C6.07748 28 5.6696 27.6329 5.58802 27.1434L4.11964 18.6594H2.93677C1.30523 18.6594 0 17.3542 0 15.7227V10.5017C0 8.8702 1.30523 7.56497 2.93677 7.56497H12.7668L22.556 0.18225ZM33.9359 2.34379C33.2833 1.73197 32.2636 1.81354 31.6517 2.46616C31.0399 3.11878 31.1215 4.13849 31.7741 4.75031C34.1806 6.87132 35.5266 9.93045 35.5266 13.1527C35.5266 16.3342 34.1398 19.3934 31.7741 21.5552C31.1215 22.167 31.0399 23.1867 31.6517 23.8393C31.978 24.2064 32.4267 24.3696 32.8346 24.3696C33.2017 24.3696 33.6096 24.2472 33.8951 23.9617C36.9542 21.2289 38.7081 17.2724 38.7081 13.1527C38.7489 9.0739 36.995 5.11741 33.9359 2.34379ZM30.2231 6.95259C29.5705 6.34077 28.5507 6.34077 27.9389 6.99338C27.3271 7.646 27.3271 8.66571 27.9797 9.27754C29.0402 10.2972 29.6112 11.6433 29.6112 13.1117C29.6112 14.58 29.0402 15.9261 27.9797 16.9458C27.3271 17.5576 27.3271 18.5773 27.9389 19.2299C28.2652 19.5562 28.6731 19.7194 29.1218 19.7194C29.5297 19.7194 29.9376 19.5562 30.2231 19.2707C31.9362 17.6392 32.8335 15.4366 32.8335 13.1117C32.8335 10.7867 31.8954 8.58413 30.2231 6.95259Z"
+                  fill="white"
+                />
+              </svg>
+            </span>
+
+            <p className="mb-0 py-3 text-center">
+              <Link href="/press-release/20210128">
+                Read the Latest Press Release
+              </Link>{' '}
+              and{' '}
+              <a
+                href="https://twitter.com/globalprivctrl"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Follow @globalprivctrl on Twitter
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {/*<!-- ABOUT SECTION --> */}
+    <section id="about" className={styles.about}>
+      <div className="container">
+        <div className={`${styles.aboutCards} row row-cols-1 row-cols-lg-3`}>
+          <div className="col">
+            <div
+              className={`card ${styles.aboutCard} h-100 text-center border-0`}
+            >
+              <img
+                src={`${process.env.publicPrefix}/img/turn-on-gpc.svg`}
+                className="card-img-top"
+                alt="Turn On GPC placeholder"
+              />
+              <div className="card-body">
+                <h2 className="card-title">
+                  Turn On <abbr title="Global Privacy Control">GPC</abbr>
+                </h2>
+                <p className="card-text">
+                  Enable Global Privacy Control to communicate your privacy
+                  preference.
                 </p>
               </div>
+            </div>
+          </div>
 
-              <div>
+          <div className="col">
+            <div
+              className={`card ${styles.aboutCard} h-100 text-center border-0`}
+            >
+              <img
+                src={`${process.env.publicPrefix}/img/browser-fights-for-you.svg`}
+                className="card-img-top"
+                alt="Turn On GPC placeholder"
+              />
+              <div className="card-body">
+                <h2 className="card-title">Send the Signal</h2>
+                <p className="card-text">
+                  Your browser will send the{' '}
+                  <abbr title="Global Privacy Control">GPC</abbr> signal to
+                  websites you visit.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="col">
+            <div
+              className={`card ${styles.aboutCard} h-100 text-center border-0`}
+            >
+              <img
+                src={`${process.env.publicPrefix}/img/live-more-privately.svg`}
+                className="card-img-top"
+                alt="Turn On GPC placeholder"
+              />
+              <div className="card-body">
+                <h2 className="card-title">Exercise Your Rights</h2>
+                <p className="card-text">
+                  Participating websites can respect your privacy rights
+                  accordingly.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* <!-- HORIZONTAL DIVIDER --> */}
+      <div className={styles.aboutSec2}>
+        <img
+          src={`${process.env.publicPrefix}/img/divider-lines.svg`}
+          alt="dividing placeholder"
+        />
+      </div>
+
+      <div className="about-sec-3">
+        <div className="container text-lg-center">
+          <div className="row justify-content-center">
+            <div className="col-lg-8">
+              <div className={`${styles.aboutText} ${styles.sectionText}`}>
+                <p>
+                  You may have noticed “Do Not Sell” and “Object To
+                  Processing” links around the web from companies complying
+                  with privacy regulations. To opt out of websites selling or
+                  sharing your personal information, you need to click these
+                  links for every site you visit.
+                </p>
+                <p>
+                  Now you can exercise your legal privacy rights in one step
+                  via Global Privacy Control (
+                  <abbr title="Global Privacy Control">GPC</abbr>), required
+                  under the California Consumer Protection Act (CCPA).
+                </p>
+
+                <p className="font-weight-bolder">
+                  Together, over a dozen organizations are developing the{' '}
+                  <abbr title="Global Privacy Control">GPC</abbr>{' '}
+                  specification.{' '}
+                  <a href="#contact">
+                    <u>Get Involved</u>
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {/*<!-- GPC SPEC SECTION --> */}
+    <section
+      id="gpc-spec"
+      className={`${styles.section} ${styles.sectionDark}`}
+    >
+      <div className="container">
+        <div className="row">
+          <div className="col-12 col-lg-5">
+            <h2 className={styles.sectionTitle}>
+              <abbr title="Global Privacy Control">GPC</abbr> lets users
+              signal their desired privacy, just by browsing.
+            </h2>
+
+            <div className={styles.sectionText}>
+              <p>
+                <abbr title="Global Privacy Control">GPC</abbr> is available as part of
+                several major browsers, extensions, and websites.
+              </p>
+            </div>
+
+            <div>
+              <Button
+                as="a"
+                variant="primary"
+                className="d-block"
+                href="https://privacycg.github.io/gpc-spec/"
+              >
+                View Full Spec
+              </Button>
+
+              <Button
+                as="a"
+                variant="secondary"
+                className="d-block mt-4"
+                href="https://global-privacy-control.glitch.me/"
+              >
+                Test against the reference server
+              </Button>
+            </div>
+
+            <p className={styles.finePrint}>
+              <small>
+                The <abbr title="Global Privacy Control">GPC</abbr> signal
+                will be intended to communicate a Do Not Sell request from a
+                global privacy control, as per{' '}
+                <a
+                  className="font-weight-bold"
+                  href="https://www.oag.ca.gov/sites/all/files/agweb/pdfs/privacy/oal-sub-final-text-of-regs.pdf"
+                >
+                  <u>CCPA-REGULATIONS §999.315</u>
+                </a>{' '}
+                for that browser or device, or, if known, the consumer. Under
+                the GDPR, the intent of the{' '}
+                <abbr title="Global Privacy Control">GPC</abbr> signal is to
+                convey a general request that data controllers limit the sale
+                or sharing of the user’s personal data to other data
+                controllers (
+                <a
+                  className="font-weight-bold"
+                  href="https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32016R0679"
+                >
+                  <u>GDPR Articles 7 & 21</u>
+                </a>
+                ). Over time, the{' '}
+                <abbr title="Global Privacy Control">GPC</abbr> signal may be
+                intended to communicate rights in other jurisdictions.
+              </small>
+            </p>
+          </div>
+          <div className="d-none d-lg-block offset-lg-1 col">
+            <img
+              src={`${process.env.publicPrefix}/img/wifi.svg`}
+              className="img-fluid desktop-illustration"
+              alt="placeholder"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {/* TESTIMONIALS */}
+    <section id="testimonials" className={styles.section}>
+      <div className="container">
+        <div className="row">
+          <div className="col-lg-12">
+            <div className={styles.carouselWrapper}>
+              <Carousel
+                items={testimonialsData.data.entries}
+
+                // {Array.from({ length: 5 }, (_, i) => ({
+                //   name: `Person ${i}`,
+                //   url: `https://example.com/${i}`,
+                //   quote:
+                //     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet suscipit orci, sit amet sodales risus. Aliquam tristique hendrerit hendrerit. Ut sit amet rhoncus ipsum. Donec semper, eros at volutpat facilisis, dolor mi aliquam tortor, nec vulputate nibh felis sit amet ipsum. Donec lacinia lacus ac nibh tempor sagittis. Suspendisse et elit ullamcorper, mattis orci et, suscipit eros. Suspendisse eget convallis libero. Phasellus mattis luctus ante, vitae sagittis risus tempor suscipit. Suspendisse at tempor felis. Sed id risus nec lectus congue luctus ut id ipsum.',
+                //   img: '/img/participating-logos/abine.svg',
+                //   position: 'Former CA Attorney General',
+                // }))}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {/* <!-- DOWNLOAD SECTION --> */}
+    <section
+      id="download"
+      className={`${styles.section} ${styles.sectionDark}`}
+    >
+      <div className="container">
+        <div className="row">
+          <div className="col-12 col-lg-5">
+            <div>
+              <h2 className={styles.sectionTitle}>
+                {downloadsData.data.title}
+              </h2>
+              <div
+                className={` ${styles.sectionText} mb-5`}
+                dangerouslySetInnerHTML={{ __html: downloadsData.html }}
+              />
+            </div>
+            <div className="d-flex mt-0 mb-4">
+              <Link href="/orgs" passHref legacyBehavior>
                 <Button
                   as="a"
                   variant="primary"
-                  className="d-block"
-                  href="https://privacycg.github.io/gpc-spec/"
+                  className={styles.bottomButton}
                 >
-                  View Full Spec
+                  View All Downloads
                 </Button>
-
-                <Button
-                  as="a"
-                  variant="secondary"
-                  className="d-block mt-4"
-                  href="https://global-privacy-control.glitch.me/"
-                >
-                  Test against the reference server
-                </Button>
-              </div>
-
-              <p className={styles.finePrint}>
-                <small>
-                  The <abbr title="Global Privacy Control">GPC</abbr> signal
-                  will be intended to communicate a Do Not Sell request from a
-                  global privacy control, as per{' '}
-                  <a
-                    className="font-weight-bold"
-                    href="https://www.oag.ca.gov/sites/all/files/agweb/pdfs/privacy/oal-sub-final-text-of-regs.pdf"
-                  >
-                    <u>CCPA-REGULATIONS §999.315</u>
-                  </a>{' '}
-                  for that browser or device, or, if known, the consumer. Under
-                  the GDPR, the intent of the{' '}
-                  <abbr title="Global Privacy Control">GPC</abbr> signal is to
-                  convey a general request that data controllers limit the sale
-                  or sharing of the user’s personal data to other data
-                  controllers (
-                  <a
-                    className="font-weight-bold"
-                    href="https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32016R0679"
-                  >
-                    <u>GDPR Articles 7 & 21</u>
-                  </a>
-                  ). Over time, the{' '}
-                  <abbr title="Global Privacy Control">GPC</abbr> signal may be
-                  intended to communicate rights in other jurisdictions.
-                </small>
-              </p>
+              </Link>
             </div>
-            <div className="d-none d-lg-block offset-lg-1 col">
-              <img
-                src={`${process.env.publicPrefix}/img/wifi.svg`}
-                className="img-fluid desktop-illustration"
-                alt="placeholder"
-              />
-            </div>
+          </div>
+
+          {/* <!-- DOWNLOAD TABLE --> */}
+          <div className="offset-lg-1 col-12 col-lg-6">
+            <ul className={styles.downloadTable}>
+              {downloadsData.data.entries.map(({ name, url, img }) => (
+                <li key={name} className="position-relative">
+                  <div className={styles.tableLogo}>
+                    <img
+                      src={`${process.env.publicPrefix}${img}`}
+                      alt={`${name} logo`}
+                    />
+                  </div>
+                  <div className={styles.tableDesc}>{name}</div>
+                  <div className={styles.tableLink}>
+                    <a
+                      className={` ${styles.tableLink} stretched-link`}
+                      href={url}
+                    >
+                      LEARN MORE <VisuallyHidden>about {name}</VisuallyHidden>
+                    </a>
+                  </div>
+                </li>
+              ))}
+            </ul>
           </div>
         </div>
-      </section>
+      </div>
+    </section>
 
-      {/* TESTIMONIALS */}
-      <section id="testimonials" className={styles.section}>
-        <div className="container">
-          <div className="row">
-            <div className="col-lg-12">
-              <div className={styles.carouselWrapper}>
-                <Carousel
-                  items={testimonialsData.data.entries}
-
-                  // {Array.from({ length: 5 }, (_, i) => ({
-                  //   name: `Person ${i}`,
-                  //   url: `https://example.com/${i}`,
-                  //   quote:
-                  //     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas sit amet suscipit orci, sit amet sodales risus. Aliquam tristique hendrerit hendrerit. Ut sit amet rhoncus ipsum. Donec semper, eros at volutpat facilisis, dolor mi aliquam tortor, nec vulputate nibh felis sit amet ipsum. Donec lacinia lacus ac nibh tempor sagittis. Suspendisse et elit ullamcorper, mattis orci et, suscipit eros. Suspendisse eget convallis libero. Phasellus mattis luctus ante, vitae sagittis risus tempor suscipit. Suspendisse at tempor felis. Sed id risus nec lectus congue luctus ut id ipsum.',
-                  //   img: '/img/participating-logos/abine.svg',
-                  //   position: 'Former CA Attorney General',
-                  // }))}
-                />
-              </div>
-            </div>
+    {/* <!-- PARTICIPATING ORGS SECTION --> */}
+    <section id="orgs" className={` ${styles.section} `}>
+      <div className="container">
+        <h2 className={`${styles.sectionTitle} text-center`}>
+          {orgsData.data.title}
+        </h2>
+        <div
+          className={`${styles.sectionText} text-center mb-5`}
+          dangerouslySetInnerHTML={{ __html: orgsData.html }}
+        />
+        <div className="row">
+          <div className="col-12">
+            <FeaturedOrganizations entries={orgsData.data.entries} />
           </div>
         </div>
-      </section>
+        <div className="d-flex justify-content-center mt-5">
+          <Link href="/orgs#Business" passHref legacyBehavior>
+            <Button as="a" variant="primary" className={styles.bottomButton}>
+              View All Organizations
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </section>
 
-      {/* <!-- DOWNLOAD SECTION --> */}
-      <section
-        id="download"
-        className={`${styles.section} ${styles.sectionDark}`}
-      >
-        <div className="container">
-          <div className="row">
-            <div className="col-12 col-lg-5">
-              <div>
-                <h2 className={styles.sectionTitle}>
-                  {downloadsData.data.title}
-                </h2>
-                <div
-                  className={` ${styles.sectionText} mb-5`}
-                  dangerouslySetInnerHTML={{ __html: downloadsData.html }}
-                />
-              </div>
-              <div className="d-flex mt-0 mb-4">
-                <Link href="/orgs" passHref>
-                  <Button
-                    as="a"
-                    variant="primary"
-                    className={styles.bottomButton}
-                  >
-                    View All Downloads
-                  </Button>
-                </Link>
-              </div>
-            </div>
+    {/* <!-- PRESS SECTION --> */}
+    <section className={` ${styles.section} ${styles.sectionDark}`}>
+      <div id="press" className="container">
+        <h2 className={`${styles.sectionTitle} text-center`}>
+          Featured Press & Announcements
+        </h2>
 
-            {/* <!-- DOWNLOAD TABLE --> */}
-            <div className="offset-lg-1 col-12 col-lg-6">
-              <ul className={styles.downloadTable}>
-                {downloadsData.data.entries.map(({ name, url, img }) => (
-                  <li key={name} className="position-relative">
-                    <div className={styles.tableLogo}>
-                      <img
-                        src={`${process.env.publicPrefix}${img}`}
-                        alt={`${name} logo`}
-                      />
-                    </div>
-                    <div className={styles.tableDesc}>{name}</div>
-                    <div className={styles.tableLink}>
-                      <a
-                        className={` ${styles.tableLink} stretched-link`}
-                        href={url}
-                      >
-                        LEARN MORE <VisuallyHidden>about {name}</VisuallyHidden>
-                      </a>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </div>
+        <div className="row justify-content-center mt-5">
+          <div className="col-12">
+            <FeaturedArticles entries={pressData.data.entries} />
           </div>
         </div>
-      </section>
 
-      {/* <!-- PARTICIPATING ORGS SECTION --> */}
-      <section id="orgs" className={` ${styles.section} `}>
-        <div className="container">
-          <h2 className={`${styles.sectionTitle} text-center`}>
-            {orgsData.data.title}
-          </h2>
-          <div
-            className={`${styles.sectionText} text-center mb-5`}
-            dangerouslySetInnerHTML={{ __html: orgsData.html }}
-          />
-          <div className="row">
-            <div className="col-12">
-              <FeaturedOrganizations entries={orgsData.data.entries} />
-            </div>
-          </div>
-          <div className="d-flex justify-content-center mt-5">
-            <Link href="/orgs#Business" passHref>
-              <Button as="a" variant="primary" className={styles.bottomButton}>
-                View All Organizations
-              </Button>
-            </Link>
+        <div className="d-flex justify-content-center mt-5">
+          <Link href="/press" passHref legacyBehavior>
+            <Button as="a" variant="primary" className={styles.bottomButton}>
+              View More Press
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </section>
+
+    {/* <!-- FAQ SECTION --> */}
+    <section className={`${styles.section}`}>
+      <div id="faq" className="container">
+        <h2 className={`${styles.sectionTitle} text-center`}>
+          {faqData.data.title}
+        </h2>
+
+        <div className="row justify-content-center mt-5">
+          <div className="col-12 col-lg-8">
+            <FaqList
+              hx="h3"
+              sections={faqData.sections}
+              isDark={true}
+              nRendered={6}
+            />
           </div>
         </div>
-      </section>
 
-      {/* <!-- PRESS SECTION --> */}
-      <section className={` ${styles.section} ${styles.sectionDark}`}>
-        <div id="press" className="container">
-          <h2 className={`${styles.sectionTitle} text-center`}>
-            Featured Press & Announcements
-          </h2>
-
-          <div className="row justify-content-center mt-5">
-            <div className="col-12">
-              <FeaturedArticles entries={pressData.data.entries} />
-            </div>
-          </div>
-
-          <div className="d-flex justify-content-center mt-5">
-            <Link href="/press" passHref>
-              <Button as="a" variant="primary" className={styles.bottomButton}>
-                View More Press
-              </Button>
-            </Link>
-          </div>
+        <div className="d-flex justify-content-center mt-5">
+          <Link href="/faq" passHref legacyBehavior>
+            <Button as="a" variant="primary" className={styles.bottomButton}>
+              View All <abbr title="frequently asked questions">FAQ</abbr>
+              <span style={{ textTransform: 'lowercase' }}>s</span>
+            </Button>
+          </Link>
         </div>
-      </section>
-
-      {/* <!-- FAQ SECTION --> */}
-      <section className={`${styles.section}`}>
-        <div id="faq" className="container">
-          <h2 className={`${styles.sectionTitle} text-center`}>
-            {faqData.data.title}
-          </h2>
-
-          <div className="row justify-content-center mt-5">
-            <div className="col-12 col-lg-8">
-              <FaqList
-                hx="h3"
-                sections={faqData.sections}
-                isDark={true}
-                nRendered={6}
-              />
-            </div>
-          </div>
-
-          <div className="d-flex justify-content-center mt-5">
-            <Link href="/faq" passHref>
-              <Button as="a" variant="primary" className={styles.bottomButton}>
-                View All <abbr title="frequently asked questions">FAQ</abbr>
-                <span style={{ textTransform: 'lowercase' }}>s</span>
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </section>
-    </>
-  );
+      </div>
+    </section>
+  </>;
 }
 
 Home.propTypes = {

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -10,23 +10,23 @@ export default function Navbar({ isLarge = false }) {
     <nav className={`${styles.navbar} navbar navbar-expand-md`}>
       <div className="navbar__logos">
         <Link href="/">
-          <a>
-            <VisuallyHidden>Home</VisuallyHidden>
-            <img
-              className="d-lg-none"
-              src={`${process.env.publicPrefix}/img/gpc-logo-mobile.svg`}
-              alt="global privacy control logo"
-              id="hero-logo"
-            />
-            <img
-              className={`d-none d-lg-block ${isLarge ? styles.headerLogoLarge : styles.headerLogoSmall}`}
-              src={`${process.env.publicPrefix}/img/${
-                isLarge ? 'gpc-logo.svg' : 'gpc-logo-small.svg'
-              }`}
-              alt="global privacy control logo"
-              id="hero-logo"
-            />
-          </a>
+
+          <VisuallyHidden>Home</VisuallyHidden>
+          <img
+            className="d-lg-none"
+            src={`${process.env.publicPrefix}/img/gpc-logo-mobile.svg`}
+            alt="global privacy control logo"
+            id="hero-logo"
+          />
+          <img
+            className={`d-none d-lg-block ${isLarge ? styles.headerLogoLarge : styles.headerLogoSmall}`}
+            src={`${process.env.publicPrefix}/img/${
+              isLarge ? 'gpc-logo.svg' : 'gpc-logo-small.svg'
+            }`}
+            alt="global privacy control logo"
+            id="hero-logo"
+          />
+
         </Link>
       </div>
 
@@ -81,38 +81,38 @@ function Links() {
   return (
     <ul className={`navbar-nav ${styles.linkList}`}>
       <li className="nav-item">
-        <Link href="/#about">
-          <a className="nav-link text-uppercase">About</a>
+        <Link href="/#about" className="nav-link text-uppercase">
+          About
         </Link>
       </li>
       <li className="nav-item">
-        <Link href="/#gpc-spec">
-          <a className="nav-link text-uppercase">Spec</a>
+        <Link href="/#gpc-spec" className="nav-link text-uppercase">
+          Spec
         </Link>
       </li>
       <li className="nav-item">
-        <Link href="/implementation">
-          <a className="nav-link text-uppercase">Implementation</a>
+        <Link href="/implementation" className="nav-link text-uppercase">
+          Implementation
         </Link>
       </li>
       <li className="nav-item">
-        <Link href="/#download">
-          <a className="nav-link text-uppercase">Download</a>
+        <Link href="/#download" className="nav-link text-uppercase">
+          Download
         </Link>
       </li>
       <li className="nav-item">
-        <Link href="/#orgs">
-          <a className="nav-link text-uppercase">Organizations</a>
+        <Link href="/#orgs" className="nav-link text-uppercase">
+          Organizations
         </Link>
       </li>
       <li className="nav-item">
-        <Link href="/#press">
-          <a className="nav-link text-uppercase">Press</a>
+        <Link href="/#press" className="nav-link text-uppercase">
+          Press
         </Link>
       </li>
       <li className="nav-item">
-        <Link href="/#faq">
-          <a className="nav-link text-uppercase">FAQ</a>
+        <Link href="/#faq" className="nav-link text-uppercase">
+          FAQ
         </Link>
       </li>
     </ul>

--- a/src/components/status-bar.js
+++ b/src/components/status-bar.js
@@ -53,7 +53,7 @@ export default function StatusBar() {
                   <span className={`${styles.statusText}`}>
                     Please
                     <Link href="/#download">
-                      <a>download a browser/extension</a>
+                      download a browser/extension
                     </Link>
                     that supports it.
                   </span>

--- a/src/pages/implementation.js
+++ b/src/pages/implementation.js
@@ -40,7 +40,10 @@ export default function ImplementationPage({ data, html, sections }) {
                 {/* <!-- HERO BUTTON --> */}
                 <div className={`row ${styles.heroBtns}`}>
                   <div className="col-sm-12 col-md-6 mb-5 mb-lg-0">
-                    <Link href={`${process.env.publicPrefix}/Implementing GPC for Publishers.pdf`} passHref>
+                    <Link
+                      href={`${process.env.publicPrefix}/Implementing GPC for Publishers.pdf`}
+                      passHref
+                      legacyBehavior>
                       <Button
                         as="a"
                         variant="primaryInverted"
@@ -173,7 +176,10 @@ export default function ImplementationPage({ data, html, sections }) {
           </div>
           <div className="row">
             <div className={`col-12 ${styles.downloadContainer}`}>
-              <Link href={`${process.env.publicPrefix}/Implementing GPC for Publishers.pdf`} passHref>
+              <Link
+                href={`${process.env.publicPrefix}/Implementing GPC for Publishers.pdf`}
+                passHref
+                legacyBehavior>
                 <Button
                   as="a"
                   variant="primary"


### PR DESCRIPTION
This is a follow up to https://github.com/globalprivacycontrol/landing-page/pull/65 - next 13.5.6 expects react 18.2.0 as a peer dependency.

cc @sballesteros 