### PR TITLE
Bump `actions/cache` version 2 -> 4.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: '18.17.0'
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4.2.0
         with:
           path: ~/.npm
           key: v1-${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Older versions of Github's `actions/cache' package are being deprecated soon. See https://github.com/actions/cache/discussions/1510