### PR TITLE
Add Jan. 2025 AdExchanger story to press list page

### DIFF
--- a/content/press.md
+++ b/content/press.md
@@ -1,6 +1,10 @@
 ---
 title: Press & Announcements
 entries:
+  - datePublished: Jan. 27, 2025
+    contentUrl: https://www.adexchanger.com/data-privacy-roundup/if-youre-a-publisher-and-you-dont-know-what-a-uoom-is-then-read-this/
+    title: "If You’re A Publisher And You Don’t Know What A UOOM Is, Then Read This"
+    source: AdExchanger
   - datePublished: Mar 23, 2023
     contentUrl: https://www.badcredit.org/news/global-privacy-control-stops-companies-from-selling-online-information/
     title: "Global Privacy Control Boosts Online Privacy by Empowering Consumers with Proactive Protection"


### PR DESCRIPTION
Allison Schiff wrote a story for web publishers on the state of UOOM compliance requirements in 2025. This is a useful update for web sites.

"Fifteen state privacy laws include a legal mandate to honor universal opt-out signals. California’s and Colorado’s provisions have been on the books since 2024. Connecticut, Montana, Nebraska, New Hampshire and Texas took effect on Jan. 1. Maryland, Minnesota and New Jersey are coming up later this year. And Delaware and Oregon’s UOOM requirements begin on Jan. 1, 2026."