### PR TITLE
Migrate reference server from Glitch to Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Apart from any logos or marks that may be contained in this repo, this work is l
 ## Resources
 
 - Read [proposed specification](https://privacycg.github.io/gpc-spec/) for technical details
-- Visit [test site](https://global-privacy-control.glitch.me) to learn how to interact with the GPC signal
+- Visit [test site](https://global-privacy-control.vercel.app) to learn how to interact with the GPC signal
 
 [cc-by]: http://creativecommons.org/licenses/by/4.0/
 [cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png

--- a/content/faq.md
+++ b/content/faq.md
@@ -59,7 +59,7 @@ title: I’m a publisher, developer, or other service. How can I support GPC?
 
 The GPC spec is easy to implement on a wide variety of websites and other
 services. The proposed specification and back-end implementation reference
-documentation are available [here](https://global-privacy-control.glitch.me/).
+documentation are available [here](https://global-privacy-control.vercel.app/).
 For additional information, please feel free to reach out on Github or Twitter
 ([@globablprivctrl](https://twitter.com/globalprivctrl)).
 

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -259,7 +259,7 @@ export default function Home({
                 as="a"
                 variant="secondary"
                 className="d-block mt-4"
-                href="https://global-privacy-control.glitch.me/"
+                href="https://global-privacy-control.vercel.app/"
               >
                 Test against the reference server
               </Button>

--- a/src/components/status-bar.js
+++ b/src/components/status-bar.js
@@ -39,7 +39,7 @@ export default function StatusBar() {
                   </span>
                   <span className={`${styles.statusCheck}`}>
                     Test against the
-                    <a href="https://global-privacy-control.glitch.me">
+                    <a href="https://global-privacy-control.vercel.app">
                       reference server
                     </a>
                     .


### PR DESCRIPTION
Glitch is shutting down their hosting services, so we are migrating the reference server to https://global-privacy-control.vercel.app/. This PR updates references to point at the new location.